### PR TITLE
Use JDK 16 EA Java Toolchain for builds (but run Gradle with JDK 11-15)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,17 +8,25 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [ '15' ]
+        java: [ '16.0.0-ea.33']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java }}
     steps:
     - name: Git checkout
       uses: actions/checkout@v1
-    - name: Set up JDK
+    - name: Set up JDK (via matrix) for Gradle Java toolchain
+      id: setupjdk
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
-    - name: Echo JAVA_HOME
+    - name: Echo JAVA_HOME (after setup-java/AdoptOpenJDK)
+      run: echo $JAVA_HOME
+    - name: Setup JDK 15 (AdoptOpenJDK) for Gradle JVM
+      uses: joschi/setup-jdk@v2
+      with:
+        java-version: 15
+        architecture: x64
+    - name: Echo JAVA_HOME (after setup-jdk/Zulu)
       run: echo $JAVA_HOME
     - name: Verify Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
@@ -30,6 +38,9 @@ jobs:
         restore-keys: ${{ runner.os }}-gradle
     - name: Build with Gradle
       run: ./gradlew buildJPackages --scan --info --stacktrace
+      env:
+        JAVA_HOME: ${{ env.JAVA_HOME_15_x64 }}
+        JDK16: ${{ env.JAVA_HOME_16_0_0_EA_33_X64 }}
     - name: Upload DMG as an artifact
       uses: actions/upload-artifact@v2
       with:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,8 +15,8 @@ Released: Under development
 
 === Build
 
-* Use `languageVersion = JavaLanguageVersion.of(15)` to require JDK 15
-* Github Actions: Build with JDK 15 (drop 14, prepare to add 16.ea)
+* Use `languageVersion = JavaLanguageVersion.of(16)` in `build.gradle` to require JDK 16 toolchain for build/test
+* Github Actions: Build with JDK 16 (but run Gradle with JDK 15)
 * Travis CI: Update Linux distro to `focal` (Ubuntu 20.04 LTS)
 
 == v0.1.0

--- a/README.adoc
+++ b/README.adoc
@@ -9,15 +9,19 @@ v0.1.0
 :caution-caption: :fire:
 :warning-caption: :warning:
 
-image:https://github.com/SupernautApp/SupernautFX/workflows/Gradle%20Build/badge.svg["Build Status", link="https://github.com/SupernautApp/SupernautFX/actions"] image:https://travis-ci.org/SupernautApp/SupernautFX.svg?branch=master["Build Status", link="https://travis-ci.org/SupernautApp/SupernautFX/"] image:https://api.bintray.com/packages/supernautapp/maven/supernaut/images/download.svg[link="https://bintray.com/supernautapp/maven/supernaut/_latestVersion"]
+image:https://github.com/SupernautApp/SupernautFX/workflows/Gradle%20Build/badge.svg["Build Status", link="https://github.com/SupernautApp/SupernautFX/actions"] image:https://api.bintray.com/packages/supernautapp/maven/supernaut/images/download.svg[link="https://bintray.com/supernautapp/maven/supernaut/_latestVersion"]
+
+// Hide Travis and Gitlab build badges until those builds are fixed (or removed).
+// image:https://gitlab.com/SupernautApp/SupernautFX/badges/master/pipeline.svg[link="https://gitlab.com/SupernautApp/SupernautFX/pipelines",title="pipeline status"]
+// image:https://travis-ci.org/SupernautApp/SupernautFX.svg?branch=master["Build Status", link="https://travis-ci.org/SupernautApp/SupernautFX/"]
 
 Supernaut.FX is a lightweight dependency injection framework for JavaFX applications. It is a wrapper around the core dependency injection capability of https://micronaut.io[Micronaut] (provided by the `micronaut-inject` JAR.) It enables the use of dependency injection in application, controller, and service objects.
 
-CAUTION:: This is an experimental framework in its very early stages. It is being used by a handful of applications in development and alpha-testing and seems to be working well so far.
+CAUTION:: This is an experimental framework in early stage development. It is being used by a handful of applications in development and alpha-testing and seems to be working well so far.
 
 == Simple and Lightweight
 
-Although it does prescribe a certain structure for an application in order to enable the injection of dependencies, it aspires to be a component library for your application with the sole concern of enabling dependency injection.
+Although Supernaut.FX does prescribe a certain structure for an application in order to enable the injection of dependencies, it aspires to be a component library for your application with the sole concern of enabling dependency injection.
 
 Perhaps in the future it could be used as a component by other full-featured JavaFX frameworks.
 
@@ -50,34 +54,35 @@ Supernaut.FX currently consists of 3 modules (JARs)
 | `app.supernaut.fx`, `micronaut-inject`
 |===
 
-Typical applications will have a compile-time dependency on `app.supernaut.fx` and a runtime dependency on `app.supernaut.fx.micronaut`.
+Typical applications will have a *compile-time* dependency on `app.supernaut.fx` and a *runtime* dependency on `app.supernaut.fx.micronaut`.
 
 You may also develop library modules for services depending only on `app.supernaut`.
 
 == Features
 
 * JavaFX-compatible Dependency Injection
-** Main application class is dependency injected
-** JavaFX FXML controllers are dependency injected
+** Main application class is dependency-injected
+** JavaFX FXML controllers are dependency-injected
 ** Service object dependency injection
-* Application class need not extend `javafx.application.Application`
+* Your main "application" class need not extend `javafx.application.Application`
 * `BrowserService` abstraction for opening links in Web Browser (abstraction of JavaFX `HostServices`)
 * Ability to customize Micronaut `BeanContext` or `ApplicationContext`
 * Micronaut-powered application configuration via `.yml`, `.json`, or `.properties` files (forthcoming, see https://github.com/SupernautApp/SupernautFX/issues/2)
 
 == Getting Started
 
-There is no user guide or "Getting Started" document, yet. Fortunately the framework is very simple -- currently only 5 (relatively simple) classes. To get started do the following:
+There is no user guide or "Getting Started" document, yet. Fortunately the framework is very simple -- currently only a handful of relatively simple classes. To get started do the following:
 
 . Clone the project
+. Make sure your `JAVA_HOME` points to a JDK 11 or newer (but not greater than 15, Gradle doesn't support that yet)
+. Configure a `JDK16` environment to point to a JDK 16 (currently in early access) installation
 . Run the sample Hello app
 .. `./gradlew supernautfx-sample-hello:run`
 . Build a `jpackage`-ed Hello app
-.. Configure the `BADASS_JLINK_JPACKAGE_HOME` environment variable
 .. `./gradlew supernautfx-sample-hello:jpackage`
 .. Open the `supernautfx-sample-hello/build/jpackage` directory and launch the native application for your platform
-. Review the https://github.com/SupernautApp/SupernautFX/tree/master/supernautfx-sample-hello/src/main/java/app/supernaut/fx/sample/hello[source code for the Hello app]
-. Review the https://github.com/SupernautApp/SupernautFX/tree/master/supernautfx/src/main/java/app/supernaut/fx[source code for Supernaut.FX]
+. Review the https://github.com/SupernautApp/SupernautFX/tree/master/supernaut-fx-sample-hello/src/main/java/app/supernaut/fx/sample/hello[source code for the Hello app]
+. Review the https://github.com/SupernautApp/SupernautFX/tree/master/supernaut-fx/src/main/java/app/supernaut/fx[source code for Supernaut.FX]
 . Start your own app!
 
 == Inspired By

--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,8 @@ allprojects {
 
     java {
         toolchain {
-            // A full build requires JDK 15 for the (incubating) `jpackage` tool
-            // When JDK 16 is final, we will upgrade to JDK 16 for a non-incubating `jpackage`
-            languageVersion = JavaLanguageVersion.of(15)
+            // A full build requires JDK 16 (Currently in early access) for the `jpackage` tool
+            languageVersion = JavaLanguageVersion.of(16)
         }
     }
 }

--- a/doc/release-process.adoc
+++ b/doc/release-process.adoc
@@ -2,8 +2,8 @@
 
 == Requirements
 
-* OpenJDK 11 or later (OpenJDK 15 is recommended: `sdk use java 15.0.0.hs-adpt`)
-* JDK 15 `jpackage` installed and `BADASS_JLINK_JPACKAGE_HOME` configured (if building sample apps with `jpackage`)
+* `JAVA_HOME` set to OpenJDK 11 or later (OpenJDK 15 is recommended: `sdk use java 15.0.2.hs-adpt`)
+* `JDK16` set to a JDK 16 (currently in early access) JDK.
 
 == Main Release Process
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,12 @@ helloAppVersion = 1.0.1
 testAppVersion = 1.0.1
 signJPackageImages = false
 
+# Look for JDK 16 vi JDK16 environment variable
+org.gradle.java.installations.fromEnv=JAVA_HOME,JDK16
+org.gradle.java.installations.auto-detect=false
+org.gradle.java.installations.auto-download=false
+
+# Dependencies
 javaFxVersion = 15.0.1
 micronautVersion = 2.2.3
 micronautTestSpockVersion = 2.1.1


### PR DESCRIPTION
Run Gradle w/ $JAVA_HOME, build tools w/ $JDK16
Also update Github Actions to do this, too.
A few unrelated README updates, as well.