### PR TITLE
Github Actions: Build with Zulu JDK 17-ea

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [ '16.0.2']
+        java: [ '17-ea']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java }}
     steps:
@@ -18,7 +18,7 @@ jobs:
       id: setupjdk
       uses: actions/setup-java@v2.2.0
       with:
-        distribution: 'temurin'
+        distribution: 'zulu'
         java-version: ${{ matrix.java }}
     - name: Verify Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ before_script:
 
 build:
   script:
-    - ./gradlew buildCI buildJPackages --scan --info --stacktrace
+    - ./gradlew -PjavaToolchainVersion=16 buildCI buildJPackages --scan --info --stacktrace
   artifacts:
     paths:
       - supernautfx/build/libs

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ testAppVersion = 1.1.5
 signJPackageImages = false
 
 # Major (whole number) version of JDK to use for javac, jlink, jpackage, etc.
-javaToolchainVersion = 16
+javaToolchainVersion = 17
 # Vendor for javaToolChain. (Must be indicator string from Gradle's KnownJvmVendor enum or empty string)
 javaToolchainVendor =
 
-# Look for JDK 16 via JDK16 environment variable
-org.gradle.java.installations.fromEnv = JAVA_HOME,JDK16
+# Look for JDK 17 via JDK17 environment variable
+org.gradle.java.installations.fromEnv = JAVA_HOME,JDK17
 
 # Auto-detection can be disabled if you have multiple JDKs of the
 # same version installed and Gradle won't reliably select the version you actually want


### PR DESCRIPTION
* Set javaToolchainVersion to 17
* Github Actions: Switch from Temurin to Zulu (until there’s a Temurin JDK 17 available)
* GitLabCI : gradle -PjavaTollchainsVersion=16 for now