### PR TITLE
Upgrade to (modular!) slf4j 2.0.0-alpha5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,6 @@ micronautVersion = 2.5.13
 micronautTestSpockVersion = 2.3.7
 groovyVersion = 3.0.9
 spockVersion = 2.0-groovy-3.0
-slf4jVersion = 1.7.32
+slf4jVersion = 2.0.0-alpha5
 # Note: Asciidoctor Gradle Plugin version is set in plugins block in main build.gradle
 asciidoctorjVersion = 2.0.0

--- a/supernaut-fx-sample-hello/build.gradle
+++ b/supernaut-fx-sample-hello/build.gradle
@@ -78,13 +78,13 @@ def os = org.gradle.internal.os.OperatingSystem.current()
 
 jlink {
     addExtraDependencies("javafx")
-    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages', '--add-modules', 'app.supernaut.fx.micronaut']
+    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages', '--add-modules', 'app.supernaut.fx.micronaut,org.slf4j.jul']
     launcher {
         name = appName
         jvmArgs = []
     }
     mergedModule {
-        requires 'java.logging'
+        requires 'org.slf4j'
     }
     jpackage {
         // See https://badass-jlink-plugin.beryx.org/releases/latest/#_jpackage for

--- a/supernaut-fx-sample-hello/src/main/java/module-info.java
+++ b/supernaut-fx-sample-hello/src/main/java/module-info.java
@@ -42,7 +42,6 @@ module app.supernaut.fx.sample.hello {
     requires static io.micronaut.inject;
 
     requires org.slf4j;
-    requires java.logging;
 
     opens app.supernaut.fx.sample.hello to javafx.graphics, javafx.fxml, java.base;
     exports app.supernaut.fx.sample.hello;

--- a/supernaut-fx-sample-minimal/build.gradle
+++ b/supernaut-fx-sample-minimal/build.gradle
@@ -51,13 +51,13 @@ def os = org.gradle.internal.os.OperatingSystem.current()
 
 jlink {
     addExtraDependencies("javafx")
-    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages', '--add-modules', 'app.supernaut.fx.micronaut']
+    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages', '--add-modules', 'app.supernaut.fx.micronaut,org.slf4j.jul']
     launcher {
         name = appName
         jvmArgs = []
     }
     mergedModule {
-        requires 'java.logging'
+        requires 'org.slf4j'
     }
     jpackage {
         // See https://badass-jlink-plugin.beryx.org/releases/latest/#_jpackage for

--- a/supernaut-fx-sample-minimal/src/main/java/module-info.java
+++ b/supernaut-fx-sample-minimal/src/main/java/module-info.java
@@ -41,7 +41,6 @@ module app.supernaut.fx.sample.minimal {
     requires static io.micronaut.inject;
 
     requires org.slf4j;
-    requires java.logging;
 
     opens app.supernaut.fx.sample.minimal to javafx.graphics, java.base;
     exports app.supernaut.fx.sample.minimal;

--- a/supernaut-fx-testapp/build.gradle
+++ b/supernaut-fx-testapp/build.gradle
@@ -52,13 +52,13 @@ def os = org.gradle.internal.os.OperatingSystem.current()
 
 jlink {
     addExtraDependencies("javafx")
-    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages', '--add-modules', 'app.supernaut.fx.micronaut']
+    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages', '--add-modules', 'app.supernaut.fx.micronaut,org.slf4j.jul']
     launcher {
         name = appName
         jvmArgs = []
     }
     mergedModule {
-        requires 'java.logging'
+        requires 'org.slf4j'
     }
     jpackage {
         // See https://badass-jlink-plugin.beryx.org/releases/latest/#_jpackage for

--- a/supernaut-fx-testapp/src/main/java/module-info.java
+++ b/supernaut-fx-testapp/src/main/java/module-info.java
@@ -28,7 +28,6 @@ module app.supernaut.fx.testapp {
     requires static io.micronaut.inject;
 
     requires org.slf4j;
-    requires java.logging;
 
     opens app.supernaut.fx.testapp to javafx.graphics, javafx.fxml, java.base;
     exports app.supernaut.fx.testapp;


### PR DESCRIPTION
* bump slf4jVersion to 2.0.0-alpha5
* Remove unneeded `requires java.logging` in app `module-info.java` files
* Add `requires ‘org.slf4j’` to `mergedModule` in app `build.gradle` files (replacing `java.logging`)
* Add `org.slf4j.jul` to jlink module path for each app