### PR TITLE
Upgrade to Zulu JDK 17 (release version)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: ['17-ea']
+        java: ['17']
         distribution: ['zulu']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.distribution }} ${{ matrix.java }}


### PR DESCRIPTION
Temurin still not ready, but it looks like Zulu 17 is final. So let's use it for now.