### PR TITLE
Deprecate the Supernaut(Main)View abstraction

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,14 +7,19 @@ A high-level view of the changes in each SupernautFX release.
 
 Released: Under development
 
-=== Dependency Upgrades
+=== Deprecations
 
-* Remove Gradle `api` and `module-info.java` dependency on `jakarta.inject(-api)`
-* Use jakarta.inject-api 2.0.1.RC1 (now with `module-info.java`) in sample/test apps
+* The `SupernautView`, `SupernautMainView`, and `FxMainView` abstraction interfaces are deprecated. Just use `Stage` directly. This abstraction added complexity without any value. I think Supernaut.FX should focus on implementing  dependency injection for JavaFX applications as simply as possible.
+* `OpenJfxApplicationAware` is also deprecated. If you need an `Application` add it to your constructor and it will be injected there.
 
 === Breaking Changes
 
 * Apps using `jakarta.inject-api` may need to add it to their Maven/Gradle build configuration
+
+=== Dependency Upgrades
+
+* Remove Gradle `api` and `module-info.java` dependency on `jakarta.inject(-api)`
+* Use jakarta.inject-api 2.0.1.RC1 (now with `module-info.java`) in sample/test apps
 
 == v0.2.0
 

--- a/apps/supernaut-fx-sample-hello/src/main/java/app/supernaut/fx/sample/hello/HelloForegroundApp.java
+++ b/apps/supernaut-fx-sample-hello/src/main/java/app/supernaut/fx/sample/hello/HelloForegroundApp.java
@@ -84,9 +84,8 @@ public class HelloForegroundApp implements FxForegroundApp {
      * {@inheritDoc}
      */
     @Override
-    public void start(FxMainView mainView) throws IOException {
+    public void start(Stage primaryStage) throws IOException {
         log.info("Starting Hello");
-        Stage primaryStage = mainView.optionalStage().orElseThrow();
         FXMLLoader loader = loaderFactory.get(getFXMLUrl("MainWindow.fxml"));
         log.debug("primaryStage root FXML: {}", loader.getLocation());
         Parent root = loader.load();

--- a/apps/supernaut-fx-sample-minimal/src/main/java/app/supernaut/fx/sample/minimal/MinimalApp.java
+++ b/apps/supernaut-fx-sample-minimal/src/main/java/app/supernaut/fx/sample/minimal/MinimalApp.java
@@ -51,9 +51,7 @@ public class MinimalApp implements FxForegroundApp {
      * {@inheritDoc}
      */
     @Override
-    public void start(FxMainView mainView) {
-        Stage primaryStage = mainView.optionalStage().orElseThrow();
-
+    public void start(Stage primaryStage) {
         var label = new Label("Hello, " + appName + " app!");
         var scene = new Scene(new StackPane(label), 300, 200);
         primaryStage.setScene(scene);

--- a/apps/supernaut-fx-testapp/src/main/java/app/supernaut/fx/testapp/TestApp.java
+++ b/apps/supernaut-fx-testapp/src/main/java/app/supernaut/fx/testapp/TestApp.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ExecutionException;
  * and stopping for startup performance measurement.
  */
 @Singleton
-public class TestApp implements FxForegroundApp, FxForegroundApp.OpenJfxApplicationAware {
+public class TestApp implements FxForegroundApp {
     private static final Logger log = LoggerFactory.getLogger(TestApp.class);
     private static boolean backgroundStart = true;
     private final FxmlLoaderFactory loaderFactory;
@@ -109,17 +109,14 @@ public class TestApp implements FxForegroundApp, FxForegroundApp.OpenJfxApplicat
     }
 
     /**
+     * @param application the JavaFX application
      * @param loaderFactory FXML loader factory
      */
-    public TestApp(FxmlLoaderFactory loaderFactory) {
+    public TestApp(Application application, FxmlLoaderFactory loaderFactory) {
         measurements.add("App constructed");
         log.info("Constructing TestApp");
-        this.loaderFactory = loaderFactory;
-    }
-
-    @Override
-    public void setJfxApplication(Application application) {
         this.fxApplication = application;
+        this.loaderFactory = loaderFactory;
     }
 
     @Override
@@ -135,8 +132,7 @@ public class TestApp implements FxForegroundApp, FxForegroundApp.OpenJfxApplicat
     }
 
     @Override
-    public void start(FxMainView mainView) throws IOException {
-        Stage primaryStage = mainView.optionalStage().orElseThrow();
+    public void start(Stage primaryStage) throws IOException {
         measurements.add("App started");
         log.info("Starting TestApp");
 

--- a/doc/supernaut-user-guide.adoc
+++ b/doc/supernaut-user-guide.adoc
@@ -85,9 +85,7 @@ public class MinimalApp extends Application {
     }
 
     @Override
-    public void start(FxMainView mainView) {
-        Stage primaryStage = mainView.optionalStage().orElseThrow();
-
+    public void start(Stage primaryStage) {
         var label = new Label("Hello, Earth!");
         var scene = new Scene(new StackPane(label), 300, 200);
         primaryStage.setScene(scene);
@@ -97,12 +95,12 @@ public class MinimalApp extends Application {
 }
 ----
 
-By simply replacing `extends Application` with `implements FxForegroundApp.FxApplicationCompat` and using the `launch()` method of the `FXLauncher` service with the name `micronaut`, it becomes a Java.FX application. Also note that the `jakarta.inject` `@Singleton` annotation has been added.
+By simply replacing `extends Application` with `implements FxForegroundApp` and using the `launch()` method of the `FXLauncher` service with the name `micronaut`, it becomes a Java.FX application. Also note that the `jakarta.inject` `@Singleton` annotation has been added.
 
 [source, java]
 ----
 @Singleton
-public class MinimalApp implements FxForegroundApp.FxApplicationCompat {
+public class MinimalApp implements FxForegroundApp {
 
     public static void main(String[] args) {
         FxLauncher.byName("micronaut").launch(args, MinimalApp.class);
@@ -124,11 +122,10 @@ This allows you to begin using Dependency Inject to configure your application. 
 [source, java]
 ----
 @Singleton
-    @Singleton
-    public static class AppConfig {
-        /** the application name */
-        public final String planetName = "Mars";
-    }
+public static class AppConfig {
+    /** the application name */
+    public final String planetName = "Mars";
+}
 ----
 
 and inject it into an added constructor of `MinimalApp`:
@@ -136,7 +133,7 @@ and inject it into an added constructor of `MinimalApp`:
 [source, java]
 ----
 @Singleton
-public class MinimalApp implements FxForegroundApp.FxApplicationCompat {
+public class MinimalApp implements FxForegroundApp {
     private final static String planetName;
 
     public static void main(String[] args) {
@@ -157,38 +154,6 @@ public class MinimalApp implements FxForegroundApp.FxApplicationCompat {
     }
 }
 ----
-
-=== Using the FxForegroundApp class
-
-The `FxForegroundApp.FxApplicationCompat` interface is provided for easy conversion from a standard JavaFX application that is a subclass of `Application`. However, the `FxForegroundApp` interface is the recommended interface to extend as it provides (the beginnings of) a layer of abstraction from JavaFX `Stage`.
-
-[source, java]
-----
-@Singleton
-public class MinimalApp implements FxForegroundApp {
-    private final static String planetName;
-
-    public static void main(String[] args) {
-        FxLauncher.byName("micronaut").launch(args, MinimalApp.class);
-    }
-
-    public MinimalApp(AppConfig config) {
-        planetName = config.planetName;
-    }
-
-    @Override
-    public void start(FxMainView mainView) {
-        Stage primaryStage = mainView.optionalStage().orElseThrow();
-
-        var label = new Label("Hello, " + planetName + "!");
-        var scene = new Scene(new StackPane(label), 300, 200);
-        primaryStage.setScene(scene);
-        primaryStage.setTitle("SupernautFX Minimal App");
-        primaryStage.show();
-    }
-}
-----
-
 
 === Dependency Injecting FXML Controllers
 

--- a/modules/app.supernaut.fx.micronaut/src/main/java/app/supernaut/fx/micronaut/test/BaseFxmlForegroundApp.java
+++ b/modules/app.supernaut.fx.micronaut/src/main/java/app/supernaut/fx/micronaut/test/BaseFxmlForegroundApp.java
@@ -39,11 +39,11 @@ public class BaseFxmlForegroundApp implements FxForegroundApp {
     /**
      * No-op start method (can be overridden)
      * 
-     * @param mainView A wrapper view containing the primary {@link Stage}
+     * @param primaryStage primary {@link Stage}
      * @throws Exception An exception occurred
      */
     @Override
-    public void start(FxMainView mainView) throws Exception {
+    public void start(Stage primaryStage) throws Exception {
     }
 
     /**

--- a/modules/app.supernaut.fx/src/main/java/app/supernaut/fx/FxForegroundApp.java
+++ b/modules/app.supernaut.fx/src/main/java/app/supernaut/fx/FxForegroundApp.java
@@ -15,6 +15,7 @@
  */
 package app.supernaut.fx;
 
+import app.supernaut.fx.internal.DefaultFxMainView;
 import javafx.application.Application;
 import javafx.stage.Stage;
 import app.supernaut.ForegroundApp;
@@ -72,11 +73,13 @@ public interface FxForegroundApp extends ForegroundApp {
      * @throws IllegalArgumentException if mainView isn't a {@link FxMainView}
      */
     @Override
-    default void start(SupernautMainView mainView) throws Exception {
+    default void start(Object mainView) throws Exception {
         if (mainView instanceof FxMainView) {
-            start(mainView);
+            start((FxMainView) mainView);
+        } else if (mainView instanceof Stage) {
+            start((Stage) mainView);
         } else {
-            throw new IllegalArgumentException("Main view must be implementation of " + FxMainView.class);
+            throw new IllegalArgumentException("Main view must be implementation of: " + Stage.class);
         }
     }
 
@@ -88,8 +91,22 @@ public interface FxForegroundApp extends ForegroundApp {
      *
      * @param mainView A wrapper view containing the primary {@link Stage}
      * @throws java.lang.Exception if something goes wrong
+     * @deprecated use {@link FxForegroundApp#start(Stage)}
      */
-    void start(FxMainView mainView) throws Exception;
+    @Deprecated
+    default void start(FxMainView mainView) throws Exception {
+        start((Object) mainView);
+    }
+
+    /**
+     * You should override this method, it will become abstract in the future
+     *
+     * @param primaryStage the primary stage
+     * @throws Exception something went wrong
+     */
+    default void start(Stage primaryStage) throws Exception {
+        start(DefaultFxMainView.of(primaryStage));
+    }
     
     /**
      * This method is called when the application should stop, and provides a
@@ -106,7 +123,9 @@ public interface FxForegroundApp extends ForegroundApp {
      * A OpenJFX-compatible {@link SupernautMainView} that potentially contains a {@link Stage}.
      * We are trying to make having a {@link Stage} optional, because in test environments (and perhaps <b>macOS</b> apps
      * if someday OpenJFX gets better <b>macOS</b> support) the Stage may not be present.
+     * @deprecated We're eliminating the concept of abstracted views, use {@link Stage} directly
      */
+    @Deprecated
     interface FxMainView extends SupernautMainView {
         /**
          * Show the stage/view
@@ -125,7 +144,9 @@ public interface FxForegroundApp extends ForegroundApp {
      * <p>{@code class MyFXForegroundApp extends Application}
      * <p>to
      * <p>{@code class MyFXForegroundApp implements FxApplicationCompat}
+     * @deprecated {@link FxForegroundApp} should be used directly
      */
+    @Deprecated
     interface FxApplicationCompat extends FxForegroundApp {
         /**
          * Start method compatible with OpenJFX start method
@@ -140,7 +161,9 @@ public interface FxForegroundApp extends ForegroundApp {
 
     /**
      * Implement this interface if you need access to the {@link Application} object instance
+     * @deprecated If you need {@link Application} inject it in your constructor
      */
+    @Deprecated
     interface OpenJfxApplicationAware extends ForegroundApp {
         /**
          * Setter that will receive the {@link Application} instance

--- a/modules/app.supernaut.fx/src/main/java/app/supernaut/fx/internal/DefaultFxMainView.java
+++ b/modules/app.supernaut.fx/src/main/java/app/supernaut/fx/internal/DefaultFxMainView.java
@@ -25,6 +25,7 @@ import java.util.Optional;
  * Simply wraps a primary {@link Stage}.
  * TODO: For extra credit create a macOS-friendly implementation of FxMainView with an invisible primaryStage
  */
+@Deprecated
 public final class DefaultFxMainView implements FxForegroundApp.FxMainView {
     private final Stage primaryStage;
 

--- a/modules/app.supernaut.fx/src/main/java/app/supernaut/fx/internal/OpenJfxProxyApplication.java
+++ b/modules/app.supernaut.fx/src/main/java/app/supernaut/fx/internal/OpenJfxProxyApplication.java
@@ -77,7 +77,7 @@ public final class OpenJfxProxyApplication extends Application {
     @Override
     public void start(Stage primaryStage) throws Exception {
         log.info("Starting SfxForegroundApp");
-        foregroundApp.start(DefaultFxMainView.of(primaryStage));
+        foregroundApp.start(primaryStage);
     }
 
     /**

--- a/modules/app.supernaut.fx/src/main/java/app/supernaut/fx/test/NoopFxForegroundApp.java
+++ b/modules/app.supernaut.fx/src/main/java/app/supernaut/fx/test/NoopFxForegroundApp.java
@@ -17,6 +17,7 @@ package app.supernaut.fx.test;
 
 import app.supernaut.fx.FxForegroundApp;
 import javafx.application.Platform;
+import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,9 +28,9 @@ public final class NoopFxForegroundApp implements FxForegroundApp {
     private static final Logger log = LoggerFactory.getLogger(NoopFxForegroundApp.class);
 
     @Override
-    public void start(FxMainView mainView) {
+    public void start(Stage primaryStage) {
         log.info("Entered");
-        mainView.show();
+        primaryStage.show();
         noop();
     }
     

--- a/modules/app.supernaut/src/main/java/app/supernaut/ForegroundApp.java
+++ b/modules/app.supernaut/src/main/java/app/supernaut/ForegroundApp.java
@@ -32,10 +32,10 @@ public interface ForegroundApp {
     /**
      * Start the application
      * 
-     * @param view Abstracted main view for the applicatino
+     * @param view Abstracted main view/window/stage for the application
      * @throws Exception an exception occurred
      */
-    void start(SupernautMainView view) throws Exception;
+    void start(Object view) throws Exception;
 
     /**
      * Stop the application
@@ -48,6 +48,7 @@ public interface ForegroundApp {
     /**
      * Marker interface for a view. In JavaFX this is a JavaFX "controller".
      */
+    @Deprecated
     interface SupernautView {
     }
 
@@ -55,6 +56,7 @@ public interface ForegroundApp {
      * Marker interface for Main View. In JavaFX this is the view contained
      * in the primary {@code Stage}.
      */
+    @Deprecated
     interface SupernautMainView extends SupernautView {
     }
 }


### PR DESCRIPTION
Existing apps should still work, but should migrate to using `Stage` directly.
The next release will remove the deprecated classes and interfaces.

This abstraction was only adding complexity, it seems to me.

Also deprecate `OpenJfxApplicationAware`