### PR TITLE
Use badass-jar-plugin to make base module (app.supernaut) JDK compatible

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,7 +30,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - name: Build with Gradle
-      run: ./gradlew buildCI buildJPackages --scan --info --stacktrace
+      run: ./gradlew -PbaseModuleJavaCompatibility=8 buildCI buildJPackages --scan --info --stacktrace
       env:
         JAVA_HOME: ${{ steps.setupjdk.outputs.path }}
     - name: Upload DMG as an artifact

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
 
 build:
   script:
-    - ./gradlew buildCI buildJPackages --scan --info --stacktrace
+    - ./gradlew -PbaseModuleJavaCompatibility=8 buildCI buildJPackages --scan --info --stacktrace
   artifacts:
     paths:
       - supernautfx/build/libs

--- a/README.adoc
+++ b/README.adoc
@@ -107,7 +107,7 @@ You may also develop library modules for services depending only on `app.superna
 
 . Clone the repository
 . Make sure your `JAVA_HOME` points to a JDK 17 or newer
-. `./gradlew buildCI buildJPackages`
+. `./gradlew -PbaseModuleJavaCompatibility=8 buildCI buildJPackages`
 
 To test one of the included sample apps:
 

--- a/doc/release-process.adoc
+++ b/doc/release-process.adoc
@@ -13,7 +13,7 @@
 .. `README.adoc`
 . Commit version bump and changelog.
 . Full build, test
-.. `./gradlew clean buildCI buildJPackages`
+.. `./gradlew -PbaseModuleJavaCompatibility=8 clean buildCI buildJPackages`
 . Tag: `git tag -a v0.x.y -m "Release 0.x.y"`
 . Push: `git push --tags origin master`
 . Publish to GitLab (and GitHub) Maven repos:

--- a/modules/app.supernaut/build.gradle
+++ b/modules/app.supernaut/build.gradle
@@ -1,11 +1,14 @@
 plugins {
     id 'java-library'
+    id 'org.beryx.jar' version '2.0.0-rc-5'
+}
+
+moduleConfig {
+    version = project.version
 }
 
 compileJava {
-    // We're currently requiring Java 9 for module-info.java, but the intention
-    // is to allow this module to be used in "modern" Android libraries and apps.
-    options.release = 9
+    options.release = (findProperty('baseModuleJavaCompatibility') ?: 9) as int
 }
 
 dependencies {


### PR DESCRIPTION
Use `badass-jar-plugin` to build the `app.supernaut` JAR to be JDK-compatible, but with `module-info.class` in the root of the JAR.  (See  https://github.com/beryx/badass-jar-plugin#readme)

See https://github.com/beryx/badass-jar-plugin/issues/2 for the request I made for changes in the plugin and @siordache 's responses.