### PR TITLE
Set Gradle javaToolchainVersion = 21

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: ['17', '21']
+        java: ['21']
         distribution: ['temurin']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.distribution }} ${{ matrix.java }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ testAppVersion = 1.4.1
 signJPackageImages = false
 
 # Major (whole number) version of JDK to use for javac, jlink, jpackage, etc.
-javaToolchainVersion = 17
+javaToolchainVersion = 21
 # Vendor for javaToolChain. (Should be indicator string from Gradle's KnownJvmVendor enum or empty string)
 # Official builds use 'Eclipse Adoptium'
 #javaToolchainVendor = Eclipse Adoptium


### PR DESCRIPTION
This requires us to drop JDK 17 from the GHA test matrix.