### PR TITLE
Upgrade to JavaFX 21 (21.0.4)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.java.installations.auto-detect = true
 org.gradle.java.installations.auto-download = false
 
 # Module Dependencies
-javaFxVersion = 17.0.15
+javaFxVersion = 21.0.4
 micronautVersion = 3.4.4
 slf4jVersion = 2.0.17
 


### PR DESCRIPTION
21.0.4 was the last release for aarch64-linux.